### PR TITLE
back api for student reactions 

### DIFF
--- a/server/@types/payloads/types.d.ts
+++ b/server/@types/payloads/types.d.ts
@@ -53,4 +53,17 @@ declare module 'payloads' {
             reason: string
         }
     }
+
+    interface ReactionRequestPayload extends Payload{
+        data:{
+            reaction: string
+        }
+    }
+
+    interface ReactionResponsePayload extends Payload{
+        data: {
+            reaction: string,
+            student_id: string
+        }
+    }
 }

--- a/server/Lecture.ts
+++ b/server/Lecture.ts
@@ -1,7 +1,7 @@
 import { v4 } from "https://deno.land/std/uuid/mod.ts";
 import { cryptoRandomString } from "https://deno.land/x/crypto_random_string@1.0.0/mod.ts";
 import { WebSocketClient } from "https://deno.land/x/websocket@v0.1.1/mod.ts";
-import { Payload, QuizRequestPayload, ServerQuizRequestPayload, ServerQuizResponsePayload, QuizEndedPayload } from "./@types/payloads/types.d.ts";
+import { Payload, QuizRequestPayload, ServerQuizRequestPayload, ServerQuizResponsePayload, QuizEndedPayload, ReactionResponsePayload } from "./@types/payloads/types.d.ts";
 import Quiz from "./Quiz.ts";
 import Student from "./Student.ts";
 import StudentList from "./StudentList.ts";
@@ -33,7 +33,18 @@ class Lecture {
 
     setWebSocketClient(wsc: WebSocketClient): void {
         this.wsc = wsc;
-        this.studentList.on("studentAdded", () => {
+        this.studentList.on("studentAdded", (student: Student) => {
+            const reactionHandler = (reaction: string) =>{
+                const payload: ReactionResponsePayload = {
+                    event: "send_student_reaction",
+                    data: {
+                        reaction: reaction,
+                        student_id: student.id
+                    }
+                };
+                this.wsc?.send(JSON.stringify(payload));
+            };
+            student.on("reaction_added", reactionHandler);
             this.wsc?.send("studentAdded");
         });
         this.studentList.on("studentDeleted", () => {

--- a/server/StudentList.ts
+++ b/server/StudentList.ts
@@ -15,7 +15,7 @@ class StudentList extends EventEmitter {
 
     addStudent(student: Student): void {
         this.students.set(student.id, student);
-        this.emit("studentAdded");
+        this.emit("studentAdded", student);
     }
 
     getStudent(index: string): Student | undefined {
@@ -24,8 +24,7 @@ class StudentList extends EventEmitter {
 
     deleteStudent(id: string): void {
         this.students.delete(id);
-        this.emit("studentDeleted"); // it is possible to send whole student via socket
-        // this.emit("studentDeleted", deletedStudent); // like this
+        this.emit("studentDeleted");
     }
 
     asArray() {

--- a/server/api/websocket-api.md
+++ b/server/api/websocket-api.md
@@ -22,7 +22,7 @@
     {
         "event": "subscribe_lecture",
         "data": {
-            "lecture_id": "7101b8b4-acd2-4838-9464-1da7aeff5335"
+            "lecture_id": "4630f745-0a10-47ec-b1c8-cddb3fcf598b"
         }
     }
     ```
@@ -69,8 +69,8 @@
     {
         "event": "subscribe_student",
         "data": {
-            "student_id": "20d7a5c9-f4f6-45ca-87a4-39ac97df3499",
-            "lecture_link": "1765661"
+            "student_id": "4fef1e0f-e77f-4302-aab6-d0cc67811368",
+            "lecture_link": "8341568"
         }
     }
     ```
@@ -210,3 +210,51 @@
     ```
 
 -   **Emitted Payload Content:** `None`
+
+
+## **sendReactionFromStudent**
+
+    Odsyła odpowiedzi na zadany quiz.
+
+-   **Requirements:** `subsribeStudentToLecture`
+-   **Event type:** `send_reaction`
+-   **Payload Content:**
+
+    ```json
+    {
+        "event": "send_reaction",
+        "data": {
+            "reaction": "POG"
+        }
+    }
+    ```
+
+-   **Response Payload:**
+
+    ```json
+    {
+        "event": "student_reaction_sent"
+    }
+    ```
+
+-   **Error Response Payload:**
+
+    ```json
+    {
+        "event": "student_reaction_not_sent"
+    }
+    ```
+
+-   **Payload Content Emitted On Event:** `student added reaction`
+
+    ```json
+    {
+        "event": "send_student_reaction",
+        "data": {
+            "reaction": "POG",
+            "student_id": "185f192f-3c51-4855-a46e-868756d66c6c"
+        }
+    }
+    ```
+
+  


### PR DESCRIPTION
I added simple api that allows student to send reactions to lecturer.
How it works:
- student sends reaction payload to server
- server responds student if his reaction is sccepted (in order to reduce reaction-spamming)
- server adds that reaction with proper timestamp to student object which also emits an event
- lecture object reacts on that event and send reaction payload to lecturer 
- lecturer gets reaction payload with reaction and student id

That is all.
Waiting for reviews <3
![original](https://user-images.githubusercontent.com/44035398/116939303-6b34cd00-ac6c-11eb-9b50-1faee213381e.gif)
